### PR TITLE
add a complete handler, this allows other popups

### DIFF
--- a/SwiftSpinner/SwiftSpinner.swift
+++ b/SwiftSpinner/SwiftSpinner.swift
@@ -125,7 +125,7 @@ public class SwiftSpinner: UIView {
     //
     // Hide the spinner
     //
-    public class func hide() {
+    public class func hide(completionFn: (Void -> Void)?) {
         let spinner = SwiftSpinner.sharedInstance
         
         if spinner.superview == nil {
@@ -139,6 +139,9 @@ public class SwiftSpinner: UIView {
                 spinner.removeFromSuperview()
                 spinner.titleLabel.font = spinner.defaultTitleFont
                 spinner.titleLabel.text = nil
+                if let completion = completionFn {
+                    completion()
+                }
         })
         
         spinner.animating = false


### PR DESCRIPTION
I am using SCLAlertView and if I do a .hide from the spinner and then right after show my alert it then kills my alert view with the spinner, this is because of the animation duration. So having a complete handler lets me work around it. For example:

```
        SwiftSpinner.hide() { _ in
            if !data.success {
                let alert = SCLAlertView()
                let message = data.messages.reduce("", combine: { (result, message: (key: String, response: String)) -> String in
                    return "\(result)\n\(message.response)"
                })
                let popup = alert.showError("Registration Failed", subTitle: message)
            }
            return
        }
```
