### PR TITLE
Replaced CGRect.zero by CGRect.zeroRect

### DIFF
--- a/SwiftSpinner/SwiftSpinner.swift
+++ b/SwiftSpinner/SwiftSpinner.swift
@@ -18,7 +18,7 @@ public class SwiftSpinner: UIView {
     //
     public class var sharedInstance: SwiftSpinner {
         struct Singleton {
-            static let instance = SwiftSpinner(frame: CGRect.zero)
+            static let instance = SwiftSpinner(frame: CGRect.zeroRect)
         }
         return Singleton.instance
     }
@@ -222,7 +222,7 @@ public class SwiftSpinner: UIView {
     //
     public override var frame: CGRect {
         didSet {
-            if frame == CGRect.zero {
+            if frame == CGRect.zeroRect {
                 return
             }
             blurView.frame = bounds


### PR DESCRIPTION
With latest XCode, I was getting this error

```
 'CGRect.Type' does not have a member named 'zero'
```

so I changed  `CGRect.zero`  by ` CGRect.zeroRect`

You may also want to have a branch (or indicate correct tag) for people using older versions of swift so they can still use this wonderful component :)

Thanks!
