### PR TITLE
SwiftSpinner Not Showing-  iOS9.2 Fix 

### DIFF
--- a/SwiftSpinner/SwiftSpinner.swift
+++ b/SwiftSpinner/SwiftSpinner.swift
@@ -100,7 +100,6 @@ public class SwiftSpinner: UIView {
     //
     public class func show(title: String, animated: Bool = true) -> SwiftSpinner {
         
-        let window = UIApplication.sharedApplication().windows.first!
         let spinner = SwiftSpinner.sharedInstance
         
         spinner.showWithDelayBlock = nil
@@ -111,7 +110,7 @@ public class SwiftSpinner: UIView {
         if spinner.superview == nil {
             //show the spinner
             spinner.alpha = 0.0
-            window.addSubview(spinner)
+            UIApplication.sharedApplication().keyWindow?.addSubview(spinner)
             
             UIView.animateWithDuration(0.33, delay: 0.0, options: .CurveEaseOut, animations: {
                 spinner.alpha = 1.0


### PR DESCRIPTION
Swift Spinner would get lost in which window in added the subview to. This fix adds it to the
current Key Window.
