### PR TITLE
Fix visible box

### DIFF
--- a/DemoApp/SwiftSpinnerDemo.xcodeproj/project.pbxproj
+++ b/DemoApp/SwiftSpinnerDemo.xcodeproj/project.pbxproj
@@ -426,6 +426,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftSpinnerDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -442,6 +443,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = SwiftSpinnerDemo/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -456,6 +458,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -477,6 +480,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				DEVELOPMENT_TEAM = "";
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",

--- a/SwiftSpinner/SwiftSpinner.swift
+++ b/SwiftSpinner/SwiftSpinner.swift
@@ -46,8 +46,10 @@ public class SwiftSpinner: UIView {
         titleLabel.textAlignment = .center
         titleLabel.lineBreakMode = .byWordWrapping
         titleLabel.adjustsFontSizeToFitWidth = true
+        titleLabel.textColor = UIColor.white
         
-        vibrancyView.contentView.addSubview(titleLabel)
+        
+        blurView.contentView.addSubview(titleLabel)
         blurView.contentView.addSubview(vibrancyView)
         
         outerCircleView.frame.size = frameSize
@@ -64,7 +66,7 @@ public class SwiftSpinner: UIView {
         outerCircle.strokeStart = 0.0
         outerCircle.strokeEnd = 1.0
         
-        vibrancyView.contentView.addSubview(outerCircleView)
+        blurView.contentView.addSubview(outerCircleView)
         
         innerCircleView.frame.size = frameSize
         
@@ -81,7 +83,7 @@ public class SwiftSpinner: UIView {
         innerCircle.strokeStart = 0.0
         innerCircle.strokeEnd = 1.0
         
-        vibrancyView.contentView.addSubview(innerCircleView)
+        blurView.contentView.addSubview(innerCircleView)
         
         isUserInteractionEnabled = true
     }


### PR DESCRIPTION
Since iOS 10 when the spinner appeared, there was for a little while a small black-ish box. Adding subviews to blurView, rather than vibrancyView, in init func fixes it.
