### PR TITLE
Update for Swift 3.1

### DIFF
--- a/SwiftSpinner/SwiftSpinner.swift
+++ b/SwiftSpinner/SwiftSpinner.swift
@@ -192,7 +192,6 @@ public class SwiftSpinner: UIView {
     // Show the spinner activity on screen, after delay. If new call to show,
     // showWithDelay or hide is maked before execution this call is discarded
     //
-    @discardableResult
     public class func show(delay: Double, title: String, animated: Bool = true) {
         let token = UUID().uuidString
         delayedTokens.append(token)
@@ -418,7 +417,7 @@ public class SwiftSpinner: UIView {
         }
         
         let duration = Double(Float(arc4random()) /  Float(UInt32.max)) * 2.0 + 1.5
-        let randomRotation = Double(Float(arc4random()) /  Float(UInt32.max)) * M_PI_4 + M_PI_4
+        let randomRotation = Double(Float(arc4random()) /  Float(UInt32.max)) * (Double.pi / 4) + (Double.pi / 4)
         
         //outer circle
         UIView.animate(withDuration: duration, delay: 0.0, usingSpringWithDamping: 0.4, initialSpringVelocity: 0.0, options: [], animations: {
@@ -441,7 +440,7 @@ public class SwiftSpinner: UIView {
         
         //inner circle
         UIView.animate(withDuration: 0.5, delay: 0.0, usingSpringWithDamping: 0.5, initialSpringVelocity: 0.0, options: [], animations: {
-            self.currentInnerRotation += CGFloat(M_PI_4)
+            self.currentInnerRotation += CGFloat(Double.pi / 4)
             self.innerCircleView.transform = CGAffineTransform(rotationAngle: self.currentInnerRotation)
             }, completion: {_ in
                 self.delay(0.5, completion: {


### PR DESCRIPTION
- Change deprecated `M_PI_4` to `(Double.pi / 4)`
- Remove `@discardableResult` on `void` function